### PR TITLE
feat: skip.voc veto for utterances *about* a cancel word (partial #7)

### DIFF
--- a/ovos_utterance_plugin_cancel/__init__.py
+++ b/ovos_utterance_plugin_cancel/__init__.py
@@ -87,27 +87,36 @@ class NevermindPlugin(UtteranceTransformer):
             skill_locale=join(dirname(__file__), "locale"))
 
     @lru_cache()
-    def get_cancel_words(self, lang: str = "en-US") -> List[str]:
-        """Return the list of cancel phrases for *lang*.
+    def _load_voc(self, base_name: str, lang: str) -> List[str]:
+        """Load a ``.voc`` for ``lang``, returning [] if none is available.
 
-        Phrases are loaded via :class:`ovos_spec_tools.LocaleResources`,
-        which applies the OVOS-INTENT-2 §2.2 smart language fallback and
-        the §3.6 sentence-template expansion. The result is LRU-cached per
-        language tag for the lifetime of the process.
-
-        Args:
-            lang: BCP-47 language tag (e.g. ``"en-US"``).
-
-        Returns:
-            List of cancel phrases, or an empty list when no locale is close
-            enough (distance ≥ 10).
-        """
+        Goes through :class:`ovos_spec_tools.LocaleResources` so the
+        OVOS-INTENT-2 §2.2 smart language fallback and §3.6 template
+        expansion apply uniformly to every vocabulary the plugin reads
+        (``cancel`` and ``skip``)."""
         try:
-            phrases = self._resources.load_vocabulary("cancel", lang)
+            phrases = self._resources.load_vocabulary(base_name, lang)
         except FileNotFoundError:
-            LOG.warning(f"cancel.voc not available for {lang}")
             return []
         return list({phrase.strip() for phrase in phrases if phrase.strip()})
+
+    def get_cancel_words(self, lang: str = "en-US") -> List[str]:
+        """Return the cancel phrases for *lang* (``cancel.voc``)."""
+        phrases = self._load_voc("cancel", lang)
+        if not phrases:
+            LOG.warning(f"cancel.voc not available for {lang}")
+        return phrases
+
+    def get_skip_prefixes(self, lang: str = "en-US") -> List[str]:
+        """Return the *veto prefixes* for *lang* (``skip.voc``).
+
+        Utterances starting with any of these phrases bypass the cancel
+        match — they are *about* a cancel word (define / spell /
+        pronounce / play / etc.) rather than commands to cancel. Partial
+        fix for issue #7. Missing ``skip.voc`` is non-fatal: the plugin
+        falls back to the historic "always check the suffix" behaviour.
+        """
+        return self._load_voc("skip", lang)
 
     def transform(
         self,
@@ -115,6 +124,11 @@ class NevermindPlugin(UtteranceTransformer):
         context: Optional[Dict[str, object]] = None,
     ) -> Tuple[List[str], Dict[str, object]]:
         """Drop utterances that end with a cancel phrase.
+
+        Skipped when the utterance starts with a phrase listed in
+        ``skip.voc`` for the active language — partial veto for the
+        edge cases tracked in issue #7 (e.g. ``"say nevermind"``,
+        ``"what is the opposite of nevermind"``).
 
         Args:
             utterances: Recognised utterance candidates.
@@ -128,8 +142,11 @@ class NevermindPlugin(UtteranceTransformer):
             original utterances are returned unchanged with an empty dict.
         """
         lang = _resolve_lang(context)
+        skip_prefixes = self.get_skip_prefixes(lang)
         for nevermind in self.get_cancel_words(lang):
             for utterance in utterances:
+                if any(utterance.startswith(p) for p in skip_prefixes):
+                    continue
                 if utterance.endswith(nevermind):
                     return [], {"canceled": True, "cancel_word": nevermind}
         return utterances, {}

--- a/ovos_utterance_plugin_cancel/locale/en-US/skip.voc
+++ b/ovos_utterance_plugin_cancel/locale/en-US/skip.voc
@@ -1,0 +1,22 @@
+# Utterance prefixes that veto the cancel transformer.
+#
+# When an utterance starts with one of these phrases, the cancel
+# suffix match is skipped — even if the utterance happens to end with
+# a word from cancel.voc. The utterance is *about* the cancel word
+# (define it, spell it, pronounce it, ask after it) rather than a
+# command to cancel.
+#
+# Partial fix for issue #7. The proper fix is post-intent dispatch
+# (only cancel when no play/say/spell/common_qa intent matched);
+# until then this prefix gate eliminates the most common false
+# positives.
+(play|say|spell|pronounce|read|repeat|write|type)
+(define|explain|translate)
+tell me (the|about|what)
+teach me
+how (do you|to|does|is)
+what (is|are|does|do)
+what's the (meaning|opposite|phonemes|translation|french|german|spanish|portuguese|italian|catalan)
+what is (another|the meaning|the opposite|the phonemes|the french|the german|the spanish|the portuguese|the italian|the catalan|the translation)
+why (do you|don't you|does not|doesn't)
+i (want|wanted|would like) (that|the|to)

--- a/test/end2end/test_cancel_plugin.py
+++ b/test/end2end/test_cancel_plugin.py
@@ -132,6 +132,37 @@ class TestCancelPluginEnabled(_CancelPluginTestBase):
             ],
         ).execute(timeout=10)
 
+    # --- skip-prefix veto (issue #7 partial fix) ---------------------------
+
+    def test_skip_prefix_vetoes_cancel(self):
+        """An utterance starting with a phrase from ``skip.voc`` bypasses
+        the cancel match even when it ends in a cancel word.
+
+        Partial fix for issue #7: utterances *about* the cancel word
+        (define / spell / pronounce / what-is / how-do-you / ...) are
+        not commands to cancel."""
+        session = Session("123")
+        session.lang = "en-US"
+        # ``nevermind that`` IS in en-US/cancel.voc — without the skip
+        # prefix, ``hello world nevermind that`` fires the cancel
+        # sequence (see test_cancel_suffix_on_arbitrary_utterance).
+        # ``spell`` as a prefix vetoes it.
+        message = self._utterance("spell nevermind that", session)
+
+        End2EndTest(
+            minicroft=self.minicroft,
+            skill_ids=[self.skill_id],
+            source_message=message,
+            expected_messages=[
+                message,
+                # No cancel sequence — intent failure (hello-world
+                # doesn't register a "spell" intent in this rig).
+                Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
+                Message("complete_intent_failure", {}),
+                Message("ovos.utterance.handled", {}),
+            ],
+        ).execute(timeout=10)
+
     # --- smoke: passthrough --------------------------------------------------
 
     def test_passthrough_without_cancel_word(self):


### PR DESCRIPTION
Partial fix for [#7](https://github.com/OpenVoiceOS/ovos-utterance-plugin-cancel/issues/7).

## Problem

The cancel transformer suffix-matches against `cancel.voc`, which produces false positives whenever the utterance *mentions* a cancel word without intending to cancel anything. Per the issue:

- `play nevermind` → would cancel instead of playing the song
- `spell forget that` → would cancel instead of spelling
- `what is the opposite of cancel` → would cancel instead of answering
- `tell me the meaning of nevermind` → likewise

The architecturally clean fix is **post-intent dispatch** — only cancel when no `play` / `say` / `spell` / `common_qa` intent matched — which needs coordination with ovos-core's IntentService. Until that lands, this PR adds an **utterance-prefix veto** as a partial fix.

## Mechanism

A new optional companion vocabulary, `locale/<lang>/skip.voc`. If an utterance **starts with** any phrase listed there, the cancel suffix match is skipped for that utterance. Missing `skip.voc` for a language is non-fatal — falls back to historic behaviour (always check the suffix).

Both `cancel.voc` and `skip.voc` go through the same `LocaleResources.load_vocabulary` path, so the OVOS-INTENT-2 §2.2 smart language fallback and §3.6 sentence-template expansion apply uniformly.

## Plugin code

Refactored:

```python
def transform(self, utterances, context=None):
    lang = _resolve_lang(context)
    skip_prefixes = self.get_skip_prefixes(lang)
    for nevermind in self.get_cancel_words(lang):
        for utterance in utterances:
            if any(utterance.startswith(p) for p in skip_prefixes):
                continue            # ← new veto
            if utterance.endswith(nevermind):
                return [], {"canceled": True, "cancel_word": nevermind}
    return utterances, {}
```

Factored the loader into a single `_load_voc(name, lang)` helper so `get_cancel_words` and `get_skip_prefixes` share the path.

## en-US skip.voc

Covers the four pattern classes called out in #7:

| Class | Examples |
|---|---|
| Imperative verbs operating on the literal word | `play`, `say`, `spell`, `pronounce`, `read`, `repeat`, `write`, `type`, `define`, `explain`, `translate` |
| Pedagogical | `tell me the …`, `teach me …` |
| Question starts | `how do you …`, `what is …`, `what's the (meaning\|opposite\|phonemes\|translation\|french\|german\|spanish\|portuguese\|italian\|catalan)`, `why don't you …` |
| Desire | `i want(ed/would like) (that\|the\|to) …` |

Other locales: empty for now. Adding non-English skip vocabularies is a community contribution and parallels the existing per-locale cancel.voc work.

## Tests

- 44 unit tests pass (none changed).
- New ovoscope case `test_skip_prefix_vetoes_cancel` — sends `"spell nevermind that"` (which would otherwise fire the cancel sequence since `"nevermind that"` is in en-US/cancel.voc) and asserts the message stream is intent-failure instead.
- Sanity-checked the four pattern classes manually against the plugin.

## Out of scope

The proper fix (post-intent veto) belongs in ovos-core's IntentService and is tracked in #7. This PR is the conservative, language-extensible workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Utterances starting with specific configured prefixes (e.g., "spell," "tell me," "what is") now bypass cancel matching, allowing them to proceed even if they contain cancel-related keywords.

* **Tests**
  * Added end-to-end test coverage for the skip prefix veto mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-utterance-plugin-cancel/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->