### PR TITLE
chore: add missing shared CI workflows

### DIFF
--- a/.github/workflows/opm-check.yml
+++ b/.github/workflows/opm-check.yml
@@ -1,0 +1,14 @@
+name: OPM Plugin Check
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  opm_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/opm-check.yml@dev
+    secrets: inherit
+    with:
+      python_version: '3.11'
+      plugin_type: 'auto'


### PR DESCRIPTION
Adds the only missing canonical OVOS shared reusable-workflow caller.

Added:
- opm-check

All other canonical callers (build-tests, coverage, lint, license-check, pip-audit, repo-health, release-preview, ovoscope, publish-stable, publish-alpha, conventional-label) were already present and already reference OpenVoiceOS/gh-automations@dev. ovoscope is included because test/end2end/ exists. No locale/ directory, so locale-check is not applicable.
