### PR TITLE
fix: remove unexpandable template line from cancel.intent locale files

### DIFF
--- a/ovos_utterance_plugin_cancel/locale/ca-ES/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/ca-ES/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/da-DK/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/da-DK/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/de-DE/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/de-DE/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/en-US/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/en-US/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/es-ES/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/es-ES/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/fr-FR/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/fr-FR/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/gl-ES/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/gl-ES/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/it-IT/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/it-IT/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/nl-NL/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/nl-NL/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/pt-BR/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/pt-BR/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/ovos_utterance_plugin_cancel/locale/pt-PT/cancel.intent
+++ b/ovos_utterance_plugin_cancel/locale/pt-PT/cancel.intent
@@ -5,4 +5,6 @@
 # The plugin currently does suffix-matching with the cancel.voc
 # vocabulary; this .intent is informational, not consumed at runtime,
 # and exists so the resource role is unambiguous in the locale folder.
-[{utterance}] <cancel>
+#
+# Pattern (needs cancel.voc for the <cancel> reference, so it stays a
+# comment rather than a live template): [{utterance}] <cancel>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-cov",
+    "ovos-spec-tools>=1.5.0a1",
 ]
 test = [
     "ovoscope<1.0.0",

--- a/test/unittests/test_locale_templates.py
+++ b/test/unittests/test_locale_templates.py
@@ -1,0 +1,47 @@
+"""Validate every locale resource line against the OVOS-INTENT-1 grammar."""
+import os
+import unittest
+
+from ovos_spec_tools.expansion import expand
+
+import ovos_utterance_plugin_cancel
+
+PACKAGE_ROOT = os.path.dirname(ovos_utterance_plugin_cancel.__file__)
+LOCALE_ROOT = os.path.join(PACKAGE_ROOT, "locale")
+RESOURCE_EXTENSIONS = (".voc", ".intent", ".dialog", ".entity", ".rx")
+
+
+def iter_resource_lines():
+    """Yield (path, line_number, line) for every template line in locale/."""
+    for dirpath, _dirs, files in os.walk(LOCALE_ROOT):
+        for fname in sorted(files):
+            if not fname.endswith(RESOURCE_EXTENSIONS):
+                continue
+            path = os.path.join(dirpath, fname)
+            with open(path, encoding="utf-8") as fh:
+                for lineno, line in enumerate(fh, 1):
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    yield path, lineno, line
+
+
+class TestLocaleTemplates(unittest.TestCase):
+    def test_locale_root_exists(self):
+        self.assertTrue(os.path.isdir(LOCALE_ROOT))
+
+    def test_all_templates_expand(self):
+        failures = []
+        for path, lineno, line in iter_resource_lines():
+            try:
+                expand(line)
+            except Exception as err:
+                rel = os.path.relpath(path, PACKAGE_ROOT)
+                failures.append(f"{rel}:{lineno}: {line!r} -> {err}")
+        self.assertEqual(
+            failures, [],
+            "malformed locale template lines:\n" + "\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Each locale's `cancel.intent` carried the line `[{utterance}] <cancel>`, whose inline `<cancel>` vocabulary reference cannot be expanded standalone; the plugin matches against `cancel.voc` at runtime, so the line is informational only and is now a comment. Adds a regression test expanding every locale template line, with ovos-spec-tools in the dev extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)