### PR TITLE
test: expect spec no-match terminal topic ovos.intent.unmatched

### DIFF
--- a/test/end2end/test_cancel_plugin.py
+++ b/test/end2end/test_cancel_plugin.py
@@ -159,7 +159,7 @@ class TestCancelPluginEnabled(_CancelPluginTestBase):
                 # No cancel sequence — intent failure (hello-world
                 # doesn't register a "spell" intent in this rig).
                 Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-                Message("complete_intent_failure", {}),
+                Message("ovos.intent.unmatched", {}),
                 Message("ovos.utterance.handled", {}),
             ],
         ).execute(timeout=10)
@@ -185,7 +185,7 @@ class TestCancelPluginEnabled(_CancelPluginTestBase):
             expected_messages=[
                 message,
                 Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-                Message("complete_intent_failure", {}),
+                Message("ovos.intent.unmatched", {}),
                 Message("ovos.utterance.handled", {}),
             ],
         ).execute(timeout=10)
@@ -215,7 +215,7 @@ class TestCancelPluginDisabled(_CancelPluginTestBase):
                 # No cancel sequence — intent failure plays the error
                 # sound and emits handled.
                 Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-                Message("complete_intent_failure", {}),
+                Message("ovos.intent.unmatched", {}),
                 Message("ovos.utterance.handled", {}),
             ],
         ).execute(timeout=10)


### PR DESCRIPTION
The ovoscope e2e suite expected `complete_intent_failure` on the no-match path, but the spec terminal event for "no plugin matched" is `ovos.intent.unmatched` (OVOS-PIPELINE-1 §6.4/§9.3), which the stack now emits — the dev CI job has been red on this stale expectation.

Updates the three no-match expectations to `ovos.intent.unmatched`. The cancelled-utterance path already conforms to OVOS-TRANSFORM-1 §8.2 (`ovos.utterance.cancelled` → `ovos.utterance.handled`) and is unchanged.

Verified locally in a fresh venv: all 5 e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)